### PR TITLE
Added a small script to replace \r\n's

### DIFF
--- a/generated/org.openhealthtools.mdht.uml.cda.consol2/.externalToolBuilders/Newline Fixer.launch
+++ b/generated/org.openhealthtools.mdht.uml.cda.consol2/.externalToolBuilders/Newline Fixer.launch
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.ant.AntBuilderLaunchConfigurationType">
+<stringAttribute key="org.eclipse.ant.ui.ATTR_ANT_AFTER_CLEAN_TARGETS" value="fixNewlines,"/>
+<booleanAttribute key="org.eclipse.ant.ui.ATTR_TARGETS_UPDATED" value="true"/>
+<booleanAttribute key="org.eclipse.ant.ui.DEFAULT_VM_INSTALL" value="false"/>
+<booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
+<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.ant.ui.AntClasspathProvider"/>
+<booleanAttribute key="org.eclipse.jdt.launching.DEFAULT_CLASSPATH" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.openhealthtools.mdht.uml.cda.consol2"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/org.openhealthtools.mdht.uml.cda.consol2/fix-newlines-in-ocl.xml}"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,"/>
+<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${workspace_loc:/org.openhealthtools.mdht.uml.cda.consol2}"/>
+</launchConfiguration>

--- a/generated/org.openhealthtools.mdht.uml.cda.consol2/fix-newlines-in-ocl.xml
+++ b/generated/org.openhealthtools.mdht.uml.cda.consol2/fix-newlines-in-ocl.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project name="project">
+    <description>
+            This is a custom ANT build script which replaces references of \r\n with \n
+            in OCL annotations, enabling source code generated on Windows and Mac/Linux platforms
+            to be the same.
+    </description>
+    <target name="fixNewlines" description="Fixes newlines in OCL annotations">
+		
+		<!-- Ensure Windows newlines are used in the OCL statements, regardless of the platform MDHT is running on -->
+		<echo>Replacing non-Windows newlines with Windows newlines</echo>
+		<replaceregexp match="\\r\\n" replace="\\\\n" byline="true">
+			<fileset dir="src/">
+    			<include name="**/*.java"/>
+			</fileset>
+		</replaceregexp>
+    </target>
+</project>


### PR DESCRIPTION
This will replace instances of \r\n with \n within the Java annotations that describe the OCL condition, allowing the same code to be generated across Windows, Mac, and Linux platforms.