### PR TITLE
Added '<tarLongFileMode>posix</tarLongFileMode>' to pom.xml.

### DIFF
--- a/generated/org.hl7.security.ds4p.contentprofile/pom.xml
+++ b/generated/org.hl7.security.ds4p.contentprofile/pom.xml
@@ -92,6 +92,7 @@
 				<inherited>true</inherited>
 				<version>2.5.4</version>
 				<configuration>
+                                        <tarLongFileMode>posix</tarLongFileMode>
 					<descriptors>
 						<descriptor>${project.parent.basedir}/runtimeassembly.xml</descriptor>
 					</descriptors>

--- a/generated/org.openhealthtools.mdht.uml.cda.consol/pom.xml
+++ b/generated/org.openhealthtools.mdht.uml.cda.consol/pom.xml
@@ -87,7 +87,8 @@
 				<artifactId>maven-assembly-plugin</artifactId>
 				<inherited>true</inherited>
 				<version>2.5.4</version>
-				<configuration>
+                                <configuration>
+                                        <tarLongFileMode>posix</tarLongFileMode>
 					<descriptors>
 						<descriptor>${project.parent.basedir}/runtimeassembly.xml</descriptor>
 					</descriptors>

--- a/generated/org.openhealthtools.mdht.uml.cda.consol2/pom.xml
+++ b/generated/org.openhealthtools.mdht.uml.cda.consol2/pom.xml
@@ -86,6 +86,7 @@
 				<inherited>true</inherited>
 				<version>2.5.4</version>
 				<configuration>
+                                        <tarLongFileMode>posix</tarLongFileMode>
 					<descriptors>
 						<descriptor>${project.parent.basedir}/runtimeassembly.xml</descriptor>
 					</descriptors>

--- a/generated/org.openhealthtools.mdht.uml.cda.mu2consol/pom.xml
+++ b/generated/org.openhealthtools.mdht.uml.cda.mu2consol/pom.xml
@@ -88,6 +88,7 @@
 				<inherited>true</inherited>
 				<version>2.5.4</version>
 				<configuration>
+                                        <tarLongFileMode>posix</tarLongFileMode>
 					<descriptors>
 						<descriptor>${project.parent.basedir}/runtimeassembly.xml</descriptor>
 					</descriptors>


### PR DESCRIPTION
This fixes the maven-assembly-plugin so that I can build on my environment. I am building from the command line on OS X El Capitan 10.11.6 and it has been failing with a 'group id too big' error.

"[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.5.4:single (default) on project org.openhealthtools.mdht.uml.cda.consol: Execution default of goal org.apache.maven.plugins:maven-assembly-plugin:2.5.4:single failed: group id '997231343' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit -> [Help 1]"

I think this fix would be pretty safe to promote and would help other developers building on similar architectures.