### PR TITLE
Skip tasks if tests not run (ie, 'mvn install -DskipTests')

### DIFF
--- a/tests/org.openhealthtools.mdht.uml.cda.consol2.tests/pom.xml
+++ b/tests/org.openhealthtools.mdht.uml.cda.consol2.tests/pom.xml
@@ -89,6 +89,7 @@
 						<id>test-reports</id>
 						<phase>test</phase>
 						<configuration>
+							<skip>${skipTests}</skip>
 							<tasks>
 								<concat destfile="target/surefire-reports/allvalidationresults.xml"
 									force="no">

--- a/tests/org.openhealthtools.mdht.uml.cda.mu2consol.tests/pom.xml
+++ b/tests/org.openhealthtools.mdht.uml.cda.mu2consol.tests/pom.xml
@@ -92,6 +92,7 @@
 						<id>test-reports</id>
 						<phase>test</phase>
 						<configuration>
+							<skip>${skipTests}</skip>
 							<tasks>
 								<concat destfile="target/surefire-reports/allvalidationresults.xml"
 									force="no">


### PR DESCRIPTION
Allows for 'mvn install -DskipTest' to succeed.